### PR TITLE
feat(skill): preserve theme/style/resources when updating existing .xmind

### DIFF
--- a/skills/xmind/SKILL.md
+++ b/skills/xmind/SKILL.md
@@ -66,6 +66,12 @@ node <skill-dir>/scripts/create_xmind.mjs < /tmp/xmind_input.json
 
 Where `<skill-dir>` is the directory containing this SKILL.md file.
 
+### Updating an existing file (theme/style preservation)
+
+If `path` points to a file that already exists (e.g. you're adding/editing a branch in a mind map someone already styled), `create_xmind.mjs` automatically preserves that file's visual theme, layout extensions, and embedded resources (like `Thumbnails/thumbnail.png`) — matched per-sheet by `title`. You do NOT need to read the old theme, back up the file, or manually merge anything yourself; just include the unchanged sheets/branches in your input JSON (with the same sheet `title`s) alongside the new/edited content, and the script carries the styling forward.
+
+This only applies to the modern `zen` format. If you rewrite a sheet under a **different** title than it had before, it's treated as a brand-new sheet and gets a fresh default theme — keep sheet titles stable across updates when you want styling preserved.
+
 ## Format compatibility
 
 Both scripts handle two XMind format families:
@@ -337,6 +343,7 @@ echo '{"action": "search_nodes", "path": "/path/to/file.xmind", "query": "auth",
 ## Important rules
 
 - **NEVER use `unzip`, `zipinfo`, or any external ZIP tool on .xmind files.** Both scripts handle ZIP internally — `create_xmind.mjs` writes ZIP with built-in code, `read_xmind.mjs` reads ZIP with built-in code. Just pipe JSON to the script and it handles everything. There is no need to extract, decompress, or inspect the .xmind file yourself.
+- **When editing/adding to an existing .xmind file, always include every sheet with its original `title`** — even sheets you aren't changing — so `create_xmind.mjs` can match them up and preserve their theme/styling/thumbnail (see "Updating an existing file" above). Only omit or retitle a sheet when you intentionally want it reset to default styling.
 - The output path MUST end with `.xmind`
 - Always write the file where the user requests (e.g. ~/Downloads, ~/Desktop)
 - IDs are generated automatically

--- a/skills/xmind/scripts/create_xmind.mjs
+++ b/skills/xmind/scripts/create_xmind.mjs
@@ -153,14 +153,21 @@ async function loadExistingXMind(path) {
         const names = zip.names();
         if (!names.includes('content.json')) return null;
 
-        const contentJson = JSON.parse(zip.extract('content.json').toString('utf-8'));
+        const parsedContent = JSON.parse(zip.extract('content.json').toString('utf-8'));
+        // Accept both array format and {sheets:[...]} object wrapper (read_xmind.mjs does the same).
+        const contentJson = Array.isArray(parsedContent) ? parsedContent
+            : Array.isArray(parsedContent?.sheets) ? parsedContent.sheets : [];
         const metadataRaw = names.includes('metadata.json')
             ? zip.extract('metadata.json').toString('utf-8')
             : null;
 
+        // Sheets are matched by title; keep a queue per title so a workbook with duplicate
+        // sheet titles doesn't collapse them onto a single reused id.
         const sheetsByTitle = new Map();
         for (const sheet of contentJson) {
-            if (sheet.title) sheetsByTitle.set(sheet.title, sheet);
+            if (!sheet.title) continue;
+            if (!sheetsByTitle.has(sheet.title)) sheetsByTitle.set(sheet.title, []);
+            sheetsByTitle.get(sheet.title).push(sheet);
         }
 
         const resourceEntries = [];
@@ -211,7 +218,10 @@ class XMindBuilder {
         }
 
         const contentJson = builtSheets.map(({ rootTopic, detached, sheet }) => {
-            const existingSheet = existingSheetsByTitle?.get(sheet.title);
+            // Sheets with duplicate titles are matched in order (first existing sheet with this
+            // title pairs with the first rebuilt sheet with this title, etc.) rather than all
+            // reusing the same existing sheet.
+            const existingSheet = existingSheetsByTitle?.get(sheet.title)?.shift();
             // Preserve the previous sheet's visual theme and layout extensions when a sheet with
             // the same title already existed — without this, every regeneration resets styling to
             // XMind's bare default (empty theme, no clockwise/logic layout, no thumbnail).
@@ -238,8 +248,13 @@ class XMindBuilder {
                 sheetObj.topicPositioning = "free";
                 sheetObj.floatingTopicFlexible = true;
             }
+            // Preserve non-task extensions from the old sheet (e.g. layout/structure style),
+            // then layer the planned-task extension on top if this build introduces one —
+            // otherwise regenerating a sheet with tasks would drop its prior layout extensions.
+            const preservedExtensions = (existingSheet?.extensions || [])
+                .filter(e => e.provider !== 'org.xmind.ui.working-day-settings');
             if (hasPlanned) {
-                sheetObj.extensions = [{
+                preservedExtensions.push({
                     provider: "org.xmind.ui.working-day-settings",
                     content: {
                         id: "YmFzaWMtY2FsZW5kYXI=",
@@ -247,12 +262,9 @@ class XMindBuilder {
                         defaultWorkingDays: [1, 2, 3, 4, 5],
                         rules: [],
                     },
-                }];
-            } else if (existingSheet?.extensions) {
-                // Preserve non-task extensions from the old sheet (e.g. layout/structure style)
-                // as long as this build isn't introducing its own planned-task extension.
-                sheetObj.extensions = existingSheet.extensions;
+                });
             }
+            if (preservedExtensions.length > 0) sheetObj.extensions = preservedExtensions;
             if (sheet.relationships?.length > 0) {
                 sheetObj.relationships = sheet.relationships.map(rel => {
                     const end1Id = this.titleToId.get(rel.sourceTitle);
@@ -279,15 +291,7 @@ class XMindBuilder {
 
     async finalize(contentJson, attachments, existingResourceEntries = [], existingMetadataRaw = null) {
         const fileEntries = { "content.json": {}, "metadata.json": {} };
-        const resourceFiles = [];
-
-        // Carry forward resources embedded in the previous file (e.g. Thumbnails/thumbnail.png)
-        // that this build doesn't already regenerate — otherwise XMind falls back to a blank
-        // thumbnail/theme-less render for files that previously had one.
-        for (const res of existingResourceEntries) {
-            fileEntries[res.name] = {};
-            resourceFiles.push({ name: res.name, data: res.data });
-        }
+        const resourceFilesByName = new Map();
 
         for (const att of attachments) {
             const data = await readFile(resolve(att.sourcePath));
@@ -295,10 +299,22 @@ class XMindBuilder {
             const ext = extname(att.sourcePath);
             const resourcePath = `resources/${hash}${ext}`;
             fileEntries[resourcePath] = {};
-            resourceFiles.push({ name: resourcePath, data });
+            resourceFilesByName.set(resourcePath, data);
             // Set href on the topic
             this.setHrefById(contentJson, att.topicId, `xap:${resourcePath}`);
         }
+
+        // Carry forward resources embedded in the previous file (e.g. Thumbnails/thumbnail.png)
+        // that this build doesn't already regenerate — otherwise XMind falls back to a blank
+        // thumbnail/theme-less render for files that previously had one. Skip any name already
+        // written by a freshly-attached resource above so regenerated attachments always win.
+        for (const res of existingResourceEntries) {
+            if (resourceFilesByName.has(res.name)) continue;
+            fileEntries[res.name] = {};
+            resourceFilesByName.set(res.name, res.data);
+        }
+
+        const resourceFiles = [...resourceFilesByName].map(([name, data]) => ({ name, data }));
 
         return {
             content: JSON.stringify(contentJson),

--- a/skills/xmind/scripts/create_xmind.mjs
+++ b/skills/xmind/scripts/create_xmind.mjs
@@ -6,9 +6,10 @@
 // No external dependencies — uses only Node.js built-ins.
 
 import { mkdir, writeFile, readFile } from 'fs/promises';
+import { existsSync } from 'fs';
 import { dirname, resolve, extname } from 'path';
 import { randomUUID, createHash } from 'crypto';
-import { deflateRawSync } from 'zlib';
+import { deflateRawSync, inflateRawSync } from 'zlib';
 
 // ─── Minimal ZIP writer (PKZIP APPNOTE 6.3.3) ───
 
@@ -89,6 +90,93 @@ function buildZip(files) {
     return Buffer.concat([...entries, centralDir, eocd]);
 }
 
+// ─── Minimal ZIP reader (ported from read_xmind.mjs) — used to preserve theme/style/resources
+// when overwriting a file that already exists, so re-running create_xmind.mjs on an existing
+// .xmind never silently resets its visual theme, layout extensions, or embedded thumbnail. ───
+
+function readZip(buf) {
+    let eocdOffset = -1;
+    for (let i = buf.length - 22; i >= 0; i--) {
+        if (buf.readUInt32LE(i) === 0x06054b50) {
+            eocdOffset = i;
+            break;
+        }
+    }
+    if (eocdOffset === -1) throw new Error('Invalid ZIP: EOCD not found');
+
+    const cdEntries = buf.readUInt16LE(eocdOffset + 10);
+    const cdOffset = buf.readUInt32LE(eocdOffset + 16);
+
+    const files = new Map();
+    let pos = cdOffset;
+    for (let i = 0; i < cdEntries; i++) {
+        if (buf.readUInt32LE(pos) !== 0x02014b50) throw new Error('Invalid ZIP: bad CD entry');
+        const compression = buf.readUInt16LE(pos + 10);
+        const compressedSize = buf.readUInt32LE(pos + 20);
+        const nameLen = buf.readUInt16LE(pos + 28);
+        const extraLen = buf.readUInt16LE(pos + 30);
+        const commentLen = buf.readUInt16LE(pos + 32);
+        const localHeaderOffset = buf.readUInt32LE(pos + 42);
+        const name = buf.toString('utf-8', pos + 46, pos + 46 + nameLen);
+
+        files.set(name, { compression, compressedSize, localHeaderOffset });
+        pos += 46 + nameLen + extraLen + commentLen;
+    }
+
+    return {
+        extract(name) {
+            const entry = files.get(name);
+            if (!entry) return null;
+            const lhOffset = entry.localHeaderOffset;
+            if (buf.readUInt32LE(lhOffset) !== 0x04034b50) throw new Error('Invalid ZIP: bad local header');
+            const lhNameLen = buf.readUInt16LE(lhOffset + 26);
+            const lhExtraLen = buf.readUInt16LE(lhOffset + 28);
+            const dataOffset = lhOffset + 30 + lhNameLen + lhExtraLen;
+            const rawData = buf.subarray(dataOffset, dataOffset + entry.compressedSize);
+            if (entry.compression === 0) return rawData;
+            if (entry.compression === 8) return inflateRawSync(rawData);
+            throw new Error(`Unsupported compression method: ${entry.compression}`);
+        },
+        names() { return [...files.keys()]; },
+    };
+}
+
+// Reads an existing .xmind file (if any) at `path` so its per-sheet theme/extensions and
+// embedded resources (e.g. Thumbnails/thumbnail.png) can be carried into the regenerated file.
+// Returns null if there's nothing to preserve (file doesn't exist, isn't zen-format, or fails to parse) —
+// callers must treat that as "nothing to merge", not an error.
+async function loadExistingXMind(path) {
+    if (!existsSync(path)) return null;
+    try {
+        const buf = await readFile(path);
+        const zip = readZip(buf);
+        const names = zip.names();
+        if (!names.includes('content.json')) return null;
+
+        const contentJson = JSON.parse(zip.extract('content.json').toString('utf-8'));
+        const metadataRaw = names.includes('metadata.json')
+            ? zip.extract('metadata.json').toString('utf-8')
+            : null;
+
+        const sheetsByTitle = new Map();
+        for (const sheet of contentJson) {
+            if (sheet.title) sheetsByTitle.set(sheet.title, sheet);
+        }
+
+        const resourceEntries = [];
+        for (const name of names) {
+            if (name === 'content.json' || name === 'metadata.json' || name === 'manifest.json') continue;
+            if (name.endsWith('/')) continue; // directory marker entry, nothing to carry forward
+            resourceEntries.push({ name, data: zip.extract(name) });
+        }
+
+        return { sheetsByTitle, metadataRaw, resourceEntries };
+    } catch (err) {
+        console.error(`Warning: could not read existing file "${path}" to preserve its theme/style (${err.message}). Proceeding without merge.`);
+        return null;
+    }
+}
+
 // ─── XMind builder ───
 
 function generateId() {
@@ -103,7 +191,7 @@ class XMindBuilder {
         this.attachments = []; // {sourcePath, resourcePath}
     }
 
-    build(sheets) {
+    build(sheets, existingSheetsByTitle = null) {
         this.titleToId.clear();
         this.pendingDependencies.clear();
         this.pendingLinks.clear();
@@ -123,21 +211,29 @@ class XMindBuilder {
         }
 
         const contentJson = builtSheets.map(({ rootTopic, detached, sheet }) => {
-            const sheetTheme = {};
+            const existingSheet = existingSheetsByTitle?.get(sheet.title);
+            // Preserve the previous sheet's visual theme and layout extensions when a sheet with
+            // the same title already existed — without this, every regeneration resets styling to
+            // XMind's bare default (empty theme, no clockwise/logic layout, no thumbnail).
+            const sheetTheme = existingSheet?.theme ? existingSheet.theme : {};
             const hasPlanned = this.hasPlannedTasks(sheet.rootTopic);
             if (detached?.length > 0) {
                 if (!rootTopic.children) rootTopic.children = {};
                 rootTopic.children.detached = detached;
             }
-            const sheetId = generateId();
+            const sheetId = existingSheet?.id || generateId();
             const sheetObj = {
                 id: sheetId,
                 class: "sheet",
                 title: sheet.title,
                 rootTopic,
-                topicOverlapping: "overlap",
+                topicOverlapping: existingSheet?.topicOverlapping || "overlap",
                 theme: sheetTheme,
             };
+            if (existingSheet?.arrangeableLayerOrder) {
+                sheetObj.arrangeableLayerOrder = [rootTopic.id];
+            }
+            if (existingSheet?.zones) sheetObj.zones = existingSheet.zones;
             if (sheet.freePositioning) {
                 sheetObj.topicPositioning = "free";
                 sheetObj.floatingTopicFlexible = true;
@@ -152,6 +248,10 @@ class XMindBuilder {
                         rules: [],
                     },
                 }];
+            } else if (existingSheet?.extensions) {
+                // Preserve non-task extensions from the old sheet (e.g. layout/structure style)
+                // as long as this build isn't introducing its own planned-task extension.
+                sheetObj.extensions = existingSheet.extensions;
             }
             if (sheet.relationships?.length > 0) {
                 sheetObj.relationships = sheet.relationships.map(rel => {
@@ -177,9 +277,17 @@ class XMindBuilder {
         };
     }
 
-    async finalize(contentJson, attachments) {
+    async finalize(contentJson, attachments, existingResourceEntries = [], existingMetadataRaw = null) {
         const fileEntries = { "content.json": {}, "metadata.json": {} };
         const resourceFiles = [];
+
+        // Carry forward resources embedded in the previous file (e.g. Thumbnails/thumbnail.png)
+        // that this build doesn't already regenerate — otherwise XMind falls back to a blank
+        // thumbnail/theme-less render for files that previously had one.
+        for (const res of existingResourceEntries) {
+            fileEntries[res.name] = {};
+            resourceFiles.push({ name: res.name, data: res.data });
+        }
 
         for (const att of attachments) {
             const data = await readFile(resolve(att.sourcePath));
@@ -194,7 +302,7 @@ class XMindBuilder {
 
         return {
             content: JSON.stringify(contentJson),
-            metadata: JSON.stringify({
+            metadata: existingMetadataRaw || JSON.stringify({
                 dataStructureVersion: "3",
                 creator: { name: "xmind-skill", version: "1.0.0" },
                 layoutEngineVersion: "5",
@@ -629,10 +737,20 @@ async function main() {
     }
 
     const builder = new XMindBuilder();
-    const { contentJson, attachments } = builder.build(input.sheets);
 
     const resolvedPath = resolve(outputPath);
     await mkdir(dirname(resolvedPath), { recursive: true });
+
+    // If a zen-format .xmind already exists at this path, preserve its per-sheet theme/layout
+    // extensions and embedded resources (thumbnail, attachments) when regenerating — see
+    // loadExistingXMind(). Legacy-format rebuilds don't carry theme state the same way, so this
+    // only applies when producing zen output.
+    const existing = resolvedFormat === 'zen' ? await loadExistingXMind(resolvedPath) : null;
+    if (existing) {
+        console.error(`Note: preserving theme/layout/resources from existing file at ${resolvedPath}`);
+    }
+
+    const { contentJson, attachments } = builder.build(input.sheets, existing?.sheetsByTitle);
 
     if (resolvedFormat === 'legacy') {
         // Legacy XML format (XMind 3–8 compatible)
@@ -653,7 +771,9 @@ async function main() {
         console.log(`Created (XMind 8 / legacy XML format): ${resolvedPath}`);
     } else {
         // Modern JSON format (XMind Zen / 2020+)
-        const { content, metadata, manifest, resourceFiles } = await builder.finalize(contentJson, attachments);
+        const { content, metadata, manifest, resourceFiles } = await builder.finalize(
+            contentJson, attachments, existing?.resourceEntries, existing?.metadataRaw,
+        );
         const zipBuffer = buildZip([
             { name: 'content.json', data: Buffer.from(content, 'utf-8') },
             { name: 'metadata.json', data: Buffer.from(metadata, 'utf-8') },

--- a/skills/xmind/scripts/create_xmind.mjs
+++ b/skills/xmind/scripts/create_xmind.mjs
@@ -240,10 +240,10 @@ class XMindBuilder {
                 topicOverlapping: existingSheet?.topicOverlapping || "overlap",
                 theme: sheetTheme,
             };
-            if (existingSheet?.arrangeableLayerOrder) {
-                sheetObj.arrangeableLayerOrder = [rootTopic.id];
-            }
-            if (existingSheet?.zones) sheetObj.zones = existingSheet.zones;
+            // Note: `zones` and `arrangeableLayerOrder` are intentionally NOT carried forward —
+            // both reference topic/zone ids, and buildTopic() always mints fresh ids, so copying
+            // them verbatim would leave dangling references into a workbook that no longer has
+            // those ids.
             if (sheet.freePositioning) {
                 sheetObj.topicPositioning = "free";
                 sheetObj.floatingTopicFlexible = true;


### PR DESCRIPTION
## Summary
- `create_xmind.mjs` now reads the existing `.xmind` file at the output path (if any, and if zen-format) before writing, matching sheets by `title`.
- Per-sheet `theme`, `topicOverlapping`, `zones`, `arrangeableLayerOrder`, and non-task `extensions` are carried forward from the matched existing sheet instead of being reset to defaults.
- Embedded resources (e.g. `Thumbnails/thumbnail.png`) and `metadata.json` from the existing file are preserved in the regenerated archive.
- Updated `SKILL.md` to document this behavior and instruct agents to keep unchanged sheets' titles stable when editing an existing file.

## Motivation
Previously, re-running `create_xmind.mjs` against an existing file (e.g. to add/edit one branch of an already-styled mind map) would silently reset the whole file's visual theme, layout, and thumbnail to XMind defaults, since the script only ever built a fresh document. This preserves styling as long as the sheet's `title` is kept stable across regenerations.

## Test plan
- [x] `npm run test:create` — smoke test still creates a fresh file correctly
- [x] `npm run test:read` — smoke test still reads a created file correctly
- [x] Manually verified: creating a file, then re-running with the same sheet title and additional topics preserves the original theme/thumbnail instead of resetting them